### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -1,9 +1,12 @@
 version: 2.1
 
 description: |
-  An orb for executing your Ghost Inspector tests and suites within your CircleCI build environment.
+  Execute your Ghost Inspector tests and suites within your CircleCI build environment.
   This orb provides commands to get up and running quicky with your Ghost Inspector integration.
-  The source for this Orb can be found here: https://github.com/ghost-inspector/circleci-orbs
+
+display:
+  source_url: https://github.com/ghost-inspector/circleci-orbs
+  home_url: https://ghostinspector.com/
 
 examples:
   execute-ghost-inspector-test:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.